### PR TITLE
Implement Docker Build Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ REPO_URI=$(aws ecr describe-repositories \
   --output text --query "repositories[0].repositoryUri")
 
 # execute the build supplying the repositoryUri
-make REGISTRY=$(REPO_URI)
+make REGISTRY=${REPO_URI}
 ```
 
 Repeat the above for SAMtools (license [here](https://github.com/samtools/htslib/blob/develop/LICENSE)), Strelka (license [here](https://github.com/Illumina/strelka/blob/master/LICENSE.txt)), and SnpEff (license is LGPLv3, as referenced [here](http://snpeff.sourceforge.net/download.html)).

--- a/tools/isaac/docker/Dockerfile
+++ b/tools/isaac/docker/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:2.7
 
+ARG VERSION="03.17.03.01"
+
 # Metadata
 LABEL container.base.image="python:2.7"
 LABEL software.name="iSAAC"
-LABEL software.version="03.17.03.01"
+LABEL software.version=${VERSION}
 LABEL software.description="Aligner for sequencing data"
 LABEL software.website="https://github.com/Illumina/Isaac3"
 LABEL software.documentation="https://github.com/Illumina/Isaac3/blob/master/src/markdown/manual.md"
@@ -16,16 +18,27 @@ RUN apt-get -y update && \
 
 RUN pip install boto3 awscli
 
-RUN git clone https://github.com/Illumina/Isaac3.git && cd /Isaac3 && git checkout 6f0191a4e0d4b332e8f34b7ced57dc6e6eb4f2f1
-RUN mkdir /iSAAC-build /isaac
-WORKDIR /iSAAC-build
-RUN /Isaac3/src/configure --prefix=/isaac
-RUN make
-RUN make install
-WORKDIR /
-RUN rm -rf /Isaac3 /iSAAC-build
+RUN wget https://github.com/Illumina/Isaac3/archive/iSAAC-${VERSION}.tar.gz && \
+    tar -xvzf iSAAC-${VERSION}.tar.gz && \
+    cd Isaac3-iSAAC-${VERSION} && \
+    mkdir /isaac && \
+    /Isaac3-iSAAC-${VERSION}/src/configure --prefix=/isaac && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /Isaac3-iSAAC-${VERSION} iSAAC-${VERSION}.tar.gz && \
+    chmod -R +x /isaac/bin/
 
-RUN chmod -R +x /isaac/bin/
+#RUN git clone https://github.com/Illumina/Isaac3.git && cd /Isaac3 && git checkout 6f0191a4e0d4b332e8f34b7ced57dc6e6eb4f2f1
+#RUN mkdir /iSAAC-build /isaac
+#WORKDIR /iSAAC-build
+#RUN /Isaac3/src/configure --prefix=/isaac
+#RUN make
+#RUN make install
+#WORKDIR /
+#RUN rm -rf /Isaac3 /iSAAC-build
+#
+#RUN chmod -R +x /isaac/bin/
 
 ENV PATH="/isaac/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib:/isaac/libexec:${LD_LIBRARY_PATH}"

--- a/tools/isaac/docker/Dockerfile
+++ b/tools/isaac/docker/Dockerfile
@@ -29,17 +29,6 @@ RUN wget https://github.com/Illumina/Isaac3/archive/iSAAC-${VERSION}.tar.gz && \
     rm -rf /Isaac3-iSAAC-${VERSION} iSAAC-${VERSION}.tar.gz && \
     chmod -R +x /isaac/bin/
 
-#RUN git clone https://github.com/Illumina/Isaac3.git && cd /Isaac3 && git checkout 6f0191a4e0d4b332e8f34b7ced57dc6e6eb4f2f1
-#RUN mkdir /iSAAC-build /isaac
-#WORKDIR /iSAAC-build
-#RUN /Isaac3/src/configure --prefix=/isaac
-#RUN make
-#RUN make install
-#WORKDIR /
-#RUN rm -rf /Isaac3 /iSAAC-build
-#
-#RUN chmod -R +x /isaac/bin/
-
 ENV PATH="/isaac/bin:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib:/isaac/libexec:${LD_LIBRARY_PATH}"
 

--- a/tools/isaac/docker/Makefile
+++ b/tools/isaac/docker/Makefile
@@ -4,7 +4,7 @@ TAG=03.17.03.01
 all: build push
 
 build:
-	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile ../..
+	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile --build-arg VERSION=$(TAG) ../..
 	docker tag $(NAME):latest $(REGISTRY):latest
 	docker tag $(NAME):$(TAG) $(REGISTRY):$(TAG)
 

--- a/tools/samtools_stats/docker/Dockerfile
+++ b/tools/samtools_stats/docker/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:2.7
 
+ARG VERSION=1.5
+
 # Metadata
 LABEL container.base.image="python:2.7"
 LABEL software.name="SAMtools"
-LABEL software.version="1.4"
+LABEL software.version=${VERSION}
 LABEL software.description="Utilities for the Sequence Alignment/Map (SAM/BAM/CRAM) formats"
 LABEL software.website="http://www.htslib.org"
 LABEL software.documentation="http://www.htslib.org/doc/samtools.html"
@@ -19,11 +21,11 @@ RUN apt-get -y update && \
 RUN pip install boto3 awscli
 
 # Application installation
-RUN wget -O /samtools-1.4.tar.bz2 \
-  https://github.com/samtools/samtools/releases/download/1.4/samtools-1.4.tar.bz2 && \
-  tar xvjf /samtools-1.4.tar.bz2 && rm /samtools-1.4.tar.bz2
+RUN wget -O /samtools-${VERSION}.tar.bz2 \
+  https://github.com/samtools/samtools/releases/download/${VERSION}/samtools-${VERSION}.tar.bz2 && \
+  tar xvjf /samtools-${VERSION}.tar.bz2 && rm /samtools-${VERSION}.tar.bz2
 
-RUN cd /samtools-1.4 && make && make install
+RUN cd /samtools-${VERSION} && make && make install
 
 # Application entry point
 COPY samtools_stats/src/run_samtools_stats.py /run_samtools_stats.py

--- a/tools/samtools_stats/docker/Makefile
+++ b/tools/samtools_stats/docker/Makefile
@@ -1,5 +1,5 @@
 NAME=samtools_stats
-TAG=1.3.1
+TAG=1.5-aws
 
 all: build push
 

--- a/tools/snpeff/docker/Dockerfile
+++ b/tools/snpeff/docker/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:2.7
 
+ARG VERSION="4.3p"
+ARG UNDERSCORE_VERSION="4_3p"
+
 # Metadata
 LABEL container.base.image="python:2.7"
 LABEL software.name="snpeff"
-LABEL software.version="4.3"
+LABEL software.version=${VERSION}
 LABEL software.description=""
 LABEL software.website=""
 LABEL software.documentation=""
@@ -19,7 +22,7 @@ RUN apt-get -y update && \
 RUN pip install boto3 awscli
 
 # Application installation
-RUN wget -O /snpeff.zip https://sourceforge.net/projects/snpeff/files/snpEff_v4_3i_core.zip && \
+RUN wget -O /snpeff.zip https://downloads.sourceforge.net/project/snpeff/snpEff_v${UNDERSCORE_VERSION}_core.zip && \
     unzip /snpeff.zip && rm /snpeff.zip
 
 RUN java -jar /snpEff/snpEff.jar download hg38

--- a/tools/snpeff/docker/Makefile
+++ b/tools/snpeff/docker/Makefile
@@ -1,10 +1,11 @@
-NAME=snpeff
-TAG=4.2
+NAME=snpeff-aws
+TAG=4.3p
+UNDERSCORE_TAG=4_3p
 
 all: build push
 
 build:
-	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile ../..
+	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile --build-arg VERSION=$(TAG) --build-arg UNDERSCORE_VERSION=$(UNDERSCORE_TAG) ../..
 	docker tag $(NAME):latest $(REGISTRY):latest
 	docker tag $(NAME):$(TAG) $(REGISTRY):$(TAG)
 

--- a/tools/strelka/docker/Dockerfile
+++ b/tools/strelka/docker/Dockerfile
@@ -2,9 +2,11 @@
 
 FROM python:2.7
 
+ARG VERSION="2.8.3"
+
 LABEL container.base.image="python:2.7"
 LABEL software.name="Strelka"
-LABEL software.version="2.7.1"
+LABEL software.version=${VERSION}
 LABEL software.description="Somatic and germline small variant caller for mapped sequencing data"
 LABEL software.website="https://github.com/Illumina/strelka"
 LABEL software.documentation="https://github.com/Illumina/strelka/blob/master/docs/userGuide/README.md"
@@ -17,9 +19,9 @@ RUN apt-get -y update && \
 
 RUN pip install boto3 awscli
 
-RUN wget https://github.com/Illumina/strelka/releases/download/v2.7.1/strelka-2.7.1.centos5_x86_64.tar.bz2 \
-    -O strelka-2.7.1.centos5_x86_64.tar.bz2 && tar xvjf strelka-2.7.1.centos5_x86_64.tar.bz2 && \
-    rm strelka-2.7.1.centos5_x86_64.tar.bz2 && mv strelka-2.7.1.centos5_x86_64 strelka
+RUN wget https://github.com/Illumina/strelka/releases/download/v${VERSION}/strelka-${VERSION}.centos5_x86_64.tar.bz2 \
+    -O strelka-${VERSION}.centos5_x86_64.tar.bz2 && tar xvjf strelka-${VERSION}.centos5_x86_64.tar.bz2 && \
+    rm strelka-${VERSION}.centos5_x86_64.tar.bz2 && mv strelka-${VERSION}.centos5_x86_64 strelka
 
 ENV LD_LIBRARY_PATH="/strelka/lib:/usr/local/lib:/usr/lib:${LD_LIBRARY_PATH}"
 ENV PATH="/strelka/bin:$PATH"

--- a/tools/strelka/docker/Makefile
+++ b/tools/strelka/docker/Makefile
@@ -1,10 +1,10 @@
 NAME=strelka
-TAG=2.7.1
+TAG=2.8.3
 
 all: build push
 
 build:
-	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile ../..
+	docker build -t $(NAME):$(TAG) -t $(NAME):latest -f Dockerfile --build-arg VERSION=$(TAG) ../..
 	docker tag $(NAME):latest $(REGISTRY):latest
 	docker tag $(NAME):$(TAG) $(REGISTRY):$(TAG)
 


### PR DESCRIPTION
I wanted to change the versions of the tools in the docker images to more recent releases and found that the versions were hard-coded into the build instructions.  I changed this so that the tag defined in the Makefile for each tool is propagated into the Dockerfile using a build argument, so its very easy to change the version going forwards.