### PR TITLE
Replaced 'AmazonEC2SpotFleetRole' with 'AmazonEC2SpotFleetTaggingRole'

### DIFF
--- a/pipeline/nested_templates/roles_template_cfn.yml
+++ b/pipeline/nested_templates/roles_template_cfn.yml
@@ -57,7 +57,7 @@ Resources:
             Action:
               - "sts:AssumeRole"
       ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+      - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 
   BatchServiceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Replaced the deprecated 'AmazonEC2SpotFleetRole' policy with 'AmazonEC2SpotFleetTaggingRole' in roles_template_cfn.yml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
